### PR TITLE
Be/wave02 tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,16 @@ def one_customer(app):
     db.session.commit()
 
 @pytest.fixture
+def second_customer(app):
+    new_customer = Customer(
+        name="Second Customer",
+        postal_code="12345",
+        phone="234-234-2345"
+    )
+    db.session.add(new_customer)
+    db.session.commit()
+
+@pytest.fixture
 def one_checked_out_video(app, client, one_customer, one_video):
     response = client.post("/rentals/check-out", json={
         "customer_id": 1,

--- a/tests/test_wave_02.py
+++ b/tests/test_wave_02.py
@@ -61,7 +61,7 @@ def test_checkout_video_no_customer_id(client, one_video, one_customer):
 
     assert response.status_code == 400
 
-def test_checkout_video_no_inventory(client, one_checked_out_video):
+def test_checkout_video_no_inventory(client, one_checked_out_video, second_customer):
     response = client.post("/rentals/check-out", json={
         "customer_id": 2,
         "video_id": 1
@@ -195,7 +195,7 @@ def test_can_delete_video_with_rental(client, one_checked_out_video):
 
 def test_cant_checkout_video_twice(client, one_checked_out_video):
     # Act
-    response = client.post("/rentals/check-in", json={
+    response = client.post("/rentals/check-out", json={
         "customer_id": 1,
         "video_id": 1
     })
@@ -222,7 +222,3 @@ def test_cant_checkin_video_twice(client, one_checked_out_video):
 
     # Assert 
     assert response.status_code == 400
-
-
-
-

--- a/tests/test_wave_02.py
+++ b/tests/test_wave_02.py
@@ -31,7 +31,7 @@ def test_checkout_video_not_found(client, one_video, one_customer):
 
     response = client.post("/rentals/check-out", json={
         "customer_id": 1,
-        "video_id": 2
+        "video_id": 100
     })
 
     assert response.status_code == 404
@@ -39,7 +39,7 @@ def test_checkout_video_not_found(client, one_video, one_customer):
 def test_checkout_customer_video_not_found(client, one_video, one_customer):
 
     response = client.post("/rentals/check-out", json={
-        "customer_id": 2,
+        "customer_id": 100,
         "video_id": 1
     })
 
@@ -63,7 +63,7 @@ def test_checkout_video_no_customer_id(client, one_video, one_customer):
 
 def test_checkout_video_no_inventory(client, one_checked_out_video):
     response = client.post("/rentals/check-out", json={
-        "customer_id": 1,
+        "customer_id": 2,
         "video_id": 1
     })
 
@@ -102,16 +102,16 @@ def test_checkin_video_no_video_id(client, one_checked_out_video):
 
 def test_checkin_video_not_found(client, one_checked_out_video):
     response = client.post("/rentals/check-in", json={
-        "customer_id": 2,
-        "video_id": 1
+        "customer_id": 1,
+        "video_id": 100
     })
 
     assert response.status_code == 404
 
 def test_checkin_customer_not_found(client, one_checked_out_video):
     response = client.post("/rentals/check-in", json={
-        "customer_id": 1,
-        "video_id": 2
+        "customer_id": 100,
+        "video_id": 1
     })
 
     assert response.status_code == 404
@@ -193,9 +193,9 @@ def test_can_delete_video_with_rental(client, one_checked_out_video):
     #Assert
     assert response.status_code == 200
 
-def test_cant_checkin_video_twice(client, one_checked_out_video):
+def test_cant_checkout_video_twice(client, one_checked_out_video):
     # Act
-    response = client.post("/rentals/check-out", json={
+    response = client.post("/rentals/check-in", json={
         "customer_id": 1,
         "video_id": 1
     })
@@ -203,7 +203,25 @@ def test_cant_checkin_video_twice(client, one_checked_out_video):
     # Assert 
     assert response.status_code == 400
 
-def test_cant_checkout_video_twice(client, one_checked_out_video):
+
+def test_cant_checkin_video_twice(client, one_checked_out_video):
+    # Act
+    response = client.post("/rentals/check-in", json={
+        "customer_id": 1,
+        "video_id": 1
+    })
+
+    # Assert 
+    assert response.status_code == 200
+
+    # Act
+    response = client.post("/rentals/check-in", json={
+        "customer_id": 1,
+        "video_id": 1
+    })
+
+    # Assert 
+    assert response.status_code == 400
 
 
 

--- a/tests/test_wave_02.py
+++ b/tests/test_wave_02.py
@@ -193,4 +193,18 @@ def test_can_delete_video_with_rental(client, one_checked_out_video):
     #Assert
     assert response.status_code == 200
 
+def test_cant_checkin_video_twice(client, one_checked_out_video):
+    # Act
+    response = client.post("/rentals/check-out", json={
+        "customer_id": 1,
+        "video_id": 1
+    })
+
+    # Assert 
+    assert response.status_code == 400
+
+def test_cant_checkout_video_twice(client, one_checked_out_video):
+
+
+
 


### PR DESCRIPTION
- Added second_customer fixture
- Added test for same customer checking out video twice (400)
- Added test for same customer checking in video twice (400)
- Corrected test for checking out with no inventory by adding second customer fixture (400)
- Changed "not found" ids to 100 from 2 to allow for other customer and video fixtures to be added
- Tests were run and passed against this solution: https://github.com/beccaelenzil/retro-video-store